### PR TITLE
Mark dependency on gmp and fix generation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,11 +12,13 @@
 		}
 	],
 	"require": {
-		"php": ">=5.3.0"
+		"php": ">=5.3.2",
+		"ext-gmp": "*"
 	},
 	"require-dev": {
 	    "mikey179/vfsStream": "1.2.0",
-	    "mockery/mockery": "dev-master@dev"
+	    "mockery/mockery": "dev-master@dev",
+	    "phpunit/phpunit": "3.7.*"
 	},
 	"autoload": {
 		"psr-0": {

--- a/src/JamesMoss/Flywheel/Repository.php
+++ b/src/JamesMoss/Flywheel/Repository.php
@@ -170,7 +170,7 @@ class Repository
     protected function generateId()
     {
         //openssl_random_pseudo_bytes
-        $num = str_replace(' ', '', microtime());
+        $num = str_replace(array(' ', '.'), '', microtime());
         $id  = gmp_strval(gmp_init($num, 10), 62);
 
         return $id;


### PR DESCRIPTION
This library has a dependency on the ext-gmp extension. This should be marked in composer. On my install, (Ubuntu 13.10 PHP 5.5.3), the unique identifier was always returning "0" since gmp_init was returning false. Removing the "." from the microtime seemed to fix the problem.
