### PR TITLE
get tests running on windows

### DIFF
--- a/test/JamesMoss/Flywheel/CachedQueryTest.php
+++ b/test/JamesMoss/Flywheel/CachedQueryTest.php
@@ -2,7 +2,9 @@
 
 namespace JamesMoss\Flywheel;
 
-class CachedQueryTest extends \PHPUnit_Framework_TestCase
+use \JamesMoss\Flywheel\TestBase;
+
+class CachedQueryTest extends TestBase
 {
     public function testCache()
     {

--- a/test/JamesMoss/Flywheel/ConfigTest.php
+++ b/test/JamesMoss/Flywheel/ConfigTest.php
@@ -2,12 +2,14 @@
 
 namespace JamesMoss\Flywheel;
 
-class ConfigTest extends \PHPUnit_Framework_TestCase
+use \JamesMoss\Flywheel\TestBase;
+
+class ConfigTest extends TestBase
 {
     public function testSlashesTidedUp()
     {
-        $path   = __DIR__ . '/fixtures/datastore/writable';
-        $config = new Config($path . '/');
+        $path   = __DIR__ . DIRECTORY_SEPARATOR . 'fixtures' . DIRECTORY_SEPARATOR . 'datastore' . DIRECTORY_SEPARATOR . 'writable';
+        $config = new Config($path . DIRECTORY_SEPARATOR);
 
         $this->assertSame($path, $config->getPath());
     }

--- a/test/JamesMoss/Flywheel/DocumentTest.php
+++ b/test/JamesMoss/Flywheel/DocumentTest.php
@@ -2,7 +2,9 @@
 
 namespace JamesMoss\Flywheel;
 
-class DocumentTest extends \PHPUnit_Framework_TestCase
+use \JamesMoss\Flywheel\TestBase;
+
+class DocumentTest extends TestBase
 {
     public function testGettingId()
     {

--- a/test/JamesMoss/Flywheel/Formatter/JSONTest.php
+++ b/test/JamesMoss/Flywheel/Formatter/JSONTest.php
@@ -2,7 +2,9 @@
 
 namespace JamesMoss\Flywheel\Formatter;
 
-class JSONTest extends \PHPUnit_Framework_TestCase
+use \JamesMoss\Flywheel\TestBase;
+
+class JSONTest extends TestBase
 {
     public function testFileExtension()
     {

--- a/test/JamesMoss/Flywheel/Formatter/MarkdownTest.php
+++ b/test/JamesMoss/Flywheel/Formatter/MarkdownTest.php
@@ -2,7 +2,9 @@
 
 namespace JamesMoss\Flywheel\Formatter;
 
-class MarkdownTest extends \PHPUnit_Framework_TestCase
+use \JamesMoss\Flywheel\TestBase;
+
+class MarkdownTest extends TestBase
 {
     public function testFileExtension()
     {
@@ -19,8 +21,8 @@ class MarkdownTest extends \PHPUnit_Framework_TestCase
             'employed' => true,
             'body'     => "Lorem ipsum dolor\nsit amet",
         );
-
-        $this->assertSame(file_get_contents(__DIR__ . '/fixtures/joe.md'), $formatter->encode($data));
+        $content = $this->normalizeLineendings(file_get_contents(__DIR__ . '/fixtures/joe.md'));
+        $this->assertSame($content, $formatter->encode($data));
     }
 
     public function testDecoding()

--- a/test/JamesMoss/Flywheel/Formatter/YAMLTest.php
+++ b/test/JamesMoss/Flywheel/Formatter/YAMLTest.php
@@ -2,7 +2,9 @@
 
 namespace JamesMoss\Flywheel\Formatter;
 
-class YAMLTest extends \PHPUnit_Framework_TestCase
+use \JamesMoss\Flywheel\TestBase;
+
+class YAMLTest extends TestBase
 {
     public function testFileExtension()
     {
@@ -18,8 +20,8 @@ class YAMLTest extends \PHPUnit_Framework_TestCase
             'age'      => 21,
             'employed' => true,
         );
-
-        $this->assertSame(file_get_contents(__DIR__ . '/fixtures/joe.yaml'), $formatter->encode($data));
+        $content = $this->normalizeLineendings(file_get_contents(__DIR__ . '/fixtures/joe.yaml'));
+        $this->assertSame($content, $formatter->encode($data));
     }
 
     public function testDecoding()

--- a/test/JamesMoss/Flywheel/NestedRepositoryTest.php
+++ b/test/JamesMoss/Flywheel/NestedRepositoryTest.php
@@ -2,7 +2,9 @@
 
 namespace JamesMoss\Flywheel;
 
-class NestedRespositoryTest extends \PHPUnit_Framework_TestCase
+use \JamesMoss\Flywheel\TestBase;
+
+class NestedRespositoryTest extends TestBase
 {
     public function testStoringDocuments()
     {

--- a/test/JamesMoss/Flywheel/QueryTest.php
+++ b/test/JamesMoss/Flywheel/QueryTest.php
@@ -2,7 +2,9 @@
 
 namespace JamesMoss\Flywheel;
 
-class QueryTest extends \PHPUnit_Framework_TestCase
+use \JamesMoss\Flywheel\TestBase;
+
+class QueryTest extends TestBase
 {
     public function testWhere()
     {

--- a/test/JamesMoss/Flywheel/RepositoryTest.php
+++ b/test/JamesMoss/Flywheel/RepositoryTest.php
@@ -2,7 +2,9 @@
 
 namespace JamesMoss\Flywheel;
 
-class RespositoryTest extends \PHPUnit_Framework_TestCase
+use \JamesMoss\Flywheel\TestBase;
+
+class RespositoryTest extends TestBase
 {
 
     /**

--- a/test/JamesMoss/Flywheel/ResultTest.php
+++ b/test/JamesMoss/Flywheel/ResultTest.php
@@ -2,7 +2,9 @@
 
 namespace JamesMoss\Flywheel;
 
-class ResultTest extends \PHPUnit_Framework_TestCase
+use \JamesMoss\Flywheel\TestBase;
+
+class ResultTest extends TestBase
 {
     public function testCountable()
     {

--- a/test/JamesMoss/Flywheel/TestBase.php
+++ b/test/JamesMoss/Flywheel/TestBase.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace JamesMoss\Flywheel;
+
+use \JamesMoss\Flywheel\TestBase;
+
+class TestBase extends \PHPUnit_Framework_TestCase 
+{
+    public function normalizeLineendings($content)
+    {
+        return str_replace("\r\n", "\n", $content);
+    }    
+}


### PR DESCRIPTION
I ran the tests on Windows and had some issues because of line endings changed by git.
I've added a function `normalizeLineendings` and moved it into a new base class.

There are still a few more issues because of the hard-coded path in `RepositoryTest`, but before I spend more time on this - is this a direction you'd like to go? I mostly work with C# these days and thus run some PHP projects on my windows box too..
