### PR TITLE
Added "select document by ID"

### DIFF
--- a/src/JamesMoss/Flywheel/Query.php
+++ b/src/JamesMoss/Flywheel/Query.php
@@ -91,9 +91,9 @@ class Query
             list($field, $operator, $predicate) = $this->where;
             $documents = array_filter($documents, function ($doc) use ($field, $operator, $predicate) {
                 if ($field == 'ID') {
-					$value = $doc->getId();
-				}
-				else if (false === strpos($field, '.')) {
+                    $value = $doc->getId();
+                }
+                else if (false === strpos($field, '.')) {
                     $value = $doc->{$field};
                 } else {
                     //multi-dimensional process

--- a/src/JamesMoss/Flywheel/Query.php
+++ b/src/JamesMoss/Flywheel/Query.php
@@ -90,7 +90,7 @@ class Query
         if ($this->where) {
             list($field, $operator, $predicate) = $this->where;
             $documents = array_filter($documents, function ($doc) use ($field, $operator, $predicate) {
-                if ($field == 'id') {
+                if ($field == 'ID') {
 					$value = $doc->getId();
 				}
 				else if (false === strpos($field, '.')) {

--- a/src/JamesMoss/Flywheel/Query.php
+++ b/src/JamesMoss/Flywheel/Query.php
@@ -90,7 +90,10 @@ class Query
         if ($this->where) {
             list($field, $operator, $predicate) = $this->where;
             $documents = array_filter($documents, function ($doc) use ($field, $operator, $predicate) {
-                if (false === strpos($field, '.')) {
+                if ($field == 'id') {
+					$value = $doc->getId();
+				}
+				else if (false === strpos($field, '.')) {
                     $value = $doc->{$field};
                 } else {
                     //multi-dimensional process

--- a/test/JamesMoss/Flywheel/QueryTest.php
+++ b/test/JamesMoss/Flywheel/QueryTest.php
@@ -84,6 +84,6 @@ class QueryTest extends TestBase
         $this->assertInstanceOf('\\JamesMoss\\Flywheel\\Result', $result);
         $this->assertEquals(1, count($result));
         $this->assertEquals(1, $result->total());
-		$this->assertEquals('Italy_ad79ef0f076d3a686ab9738925f4dd2c7e69d7d1', $result->first()->getId());
+        $this->assertEquals('Italy_ad79ef0f076d3a686ab9738925f4dd2c7e69d7d1', $result->first()->getId());
     }
 }

--- a/test/JamesMoss/Flywheel/QueryTest.php
+++ b/test/JamesMoss/Flywheel/QueryTest.php
@@ -79,7 +79,7 @@ class QueryTest extends TestBase
         $repo   = new Repository('countries', $config);
         $query  = new Query($repo);
 
-        $query->where('id', '==', 'Italy_ad79ef0f076d3a686ab9738925f4dd2c7e69d7d1');
+        $query->where('ID', '==', 'Italy_ad79ef0f076d3a686ab9738925f4dd2c7e69d7d1');
         $result = $query->execute();
         $this->assertInstanceOf('\\JamesMoss\\Flywheel\\Result', $result);
         $this->assertEquals(1, count($result));

--- a/test/JamesMoss/Flywheel/QueryTest.php
+++ b/test/JamesMoss/Flywheel/QueryTest.php
@@ -71,4 +71,19 @@ class QueryTest extends TestBase
         $result = $query->execute();
         $this->assertEquals(1, count($result));
     }
+	
+	public function testWhereById()
+    {
+        $path   = __DIR__ . '/fixtures/datastore/querytest';
+        $config = new Config($path . '/');
+        $repo   = new Repository('countries', $config);
+        $query  = new Query($repo);
+
+        $query->where('id', '==', 'Italy_ad79ef0f076d3a686ab9738925f4dd2c7e69d7d1');
+        $result = $query->execute();
+        $this->assertInstanceOf('\\JamesMoss\\Flywheel\\Result', $result);
+        $this->assertEquals(1, count($result));
+        $this->assertEquals(1, $result->total());
+		$this->assertEquals('Italy_ad79ef0f076d3a686ab9738925f4dd2c7e69d7d1', $result->first()->getId());
+    }
 }


### PR DESCRIPTION
Sometimes it's useful to retrieve a previously saved document by knowing its ID (so the value returned by `getId()` method). In particular when IDs are not auto-generated, but follow a pattern defined by the admin.
NOTE: test case has not been... tested so much. Please double check.