### PR TITLE
Replaced glob() with FilesystemIterator

### DIFF
--- a/src/JamesMoss/Flywheel/Repository.php
+++ b/src/JamesMoss/Flywheel/Repository.php
@@ -251,7 +251,8 @@ class Repository
     public function getAllFiles()
     {
         $ext       = $this->formatter->getFileExtension();
-        $files     = glob($this->path . DIRECTORY_SEPARATOR . '*.' . $ext);
+        $filesystemIterator = new \FilesystemIterator($this->path, \FilesystemIterator::SKIP_DOTS);
+        $files = new \RegexIterator($filesystemIterator, "/\\.{$ext}$/");
 
         return $files;
     }


### PR DESCRIPTION
Replaced usage of glob() function in Repository::getAllFiles().
This enables any valid streamWrapper to support directory scanning.