### PR TITLE
Correction fread() in findAll()

### DIFF
--- a/src/JamesMoss/Flywheel/Repository.php
+++ b/src/JamesMoss/Flywheel/Repository.php
@@ -89,7 +89,12 @@ class Repository
 
         foreach ($files as $file) {
             $fp       = fopen($file, 'r');
-            $contents = fread($fp, filesize($file));
+            
+            $contents = null;
+            if(($filesize = filesize($file)) > 0) {
+                $contents = fread($fp, $filesize);
+            }
+            
             fclose($fp);
 
             $data = $this->formatter->decode($contents);


### PR DESCRIPTION
Problem - Warning: fread(): Length parameter must be greater than 0
Solution - Check file size  before use fread.