### PR TITLE
Cache composer files on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,10 @@ jobs:
     - php: 5.4
       dist: trusty
 
-install:
+before_install:
   - if [[ ${TRAVIS_PHP_VERSION:0:3} < "7.1" ]]; then rm composer.lock; fi
+
+install:
   - composer install
 
 script:
@@ -22,3 +24,7 @@ script:
 after_script:
   - wget https://scrutinizer-ci.com/ocular.phar
   - php ocular.phar code-coverage:upload --format=php-clover coverage.clover
+
+cache:
+  directories:
+    - $HOME/.composer/cache


### PR DESCRIPTION
It's not that much faster but it's always good to take.

#### before
![cache-composer-before](https://user-images.githubusercontent.com/23519418/69918153-c9092800-146e-11ea-99e5-a22456ef0284.png)
#### after
![travis-cache-after](https://user-images.githubusercontent.com/23519418/69963465-88fa8180-1510-11ea-814d-5e8d3ffff2fa.png)

