### PR TITLE
build: run php 5.3 tests again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ jobs:
       dist: trusty
     - php: 5.4
       dist: trusty
+    - php: 5.3.29
+      dist: precise
 
 install:
   - if [[ ${TRAVIS_PHP_VERSION:0:3} < "7.1" ]]; then rm composer.lock; fi

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
 	"require-dev": {
 		"mikey179/vfsstream": "^1.6",
 		"mockery/mockery": "1.* || 0.*",
-		"mustangostang/spyc": "^0.6",
+		"mustangostang/spyc": "dev-master#eba310c",
 		"phpunit/phpunit": "7.* || 4.*"
 	},
 	"suggest": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "ac5e07039672da7f040f0ff8506869f6",
+    "content-hash": "857529a9f504739efe6a1d43c40bdb5d",
     "packages": [],
     "packages-dev": [
         {
@@ -225,7 +225,7 @@
         },
         {
             "name": "mustangostang/spyc",
-            "version": "0.6.3",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "git@github.com:mustangostang/spyc.git",
@@ -1540,7 +1540,7 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.13.0",
+            "version": "v1.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
@@ -1687,7 +1687,9 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "mustangostang/spyc": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/test/JamesMoss/Flywheel/QueryExecuterTest.php
+++ b/test/JamesMoss/Flywheel/QueryExecuterTest.php
@@ -85,15 +85,15 @@ class QueryExecuterTest extends TestBase
                   ->orWhere('language.0', '==', 'English');
             });
 
-        $qe = new QueryExecuter($this->getRepo('countries'), $pred, array(), array());
+        $qe = new QueryExecuter($this->getRepo('countries'), $pred, array(), array('name ASC'));
 
         $result = $qe->run();
 
         $this->assertEquals(3, $result->total());
 
-        $this->assertEquals('Vatican City', $result->first()->name);
+        $this->assertEquals('Gibraltar', $result->first()->name);
         $this->assertEquals('San Marino', $result[1]->name);
-        $this->assertEquals('Gibraltar', $result[2]->name);
+        $this->assertEquals('Vatican City', $result[2]->name);
     }
 
     public function testInOperator()
@@ -103,17 +103,15 @@ class QueryExecuterTest extends TestBase
             ->andWhere('population', '<', 40000)
             ->andWhere('language.0', 'IN', array('Italian', 'English'));
 
-        $qe = new QueryExecuter($this->getRepo('countries'), $pred, array(), array());
+        $qe = new QueryExecuter($this->getRepo('countries'), $pred, array(), array('name ASC'));
 
         $result = $qe->run();
 
         $this->assertEquals(3, $result->total());
 
-        $this->assertEquals('Vatican City', $result->first()->name);
-        // The two following assertions doesn't work on PHP 5.4 and 5.5
-        // probably because these versions need mockery 0.* instead of 1.*
-        // $this->assertEquals('San Marino', $result[1]->name);
-        // $this->assertEquals('Gibraltar', $result[2]->name);
+        $this->assertEquals('Gibraltar', $result->first()->name);
+        $this->assertEquals('San Marino', $result[1]->name);
+        $this->assertEquals('Vatican City', $result[2]->name);
     }
 
     public function testSimpleOrdering()


### PR DESCRIPTION
As I managed to make PHP 5.3 tests work on Travis again.
I just needed to add an ordering to make `IN` and `SubPredicate`  tests work as expected across all PHP versions.